### PR TITLE
fix(deps) bump django-extensions

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -6,7 +6,7 @@ chardet==3.0.4
 decorator==4.3.0
 Django==2.2.13
 django-environ==0.4.5
-django-extensions==2.1.2
+django-extensions==2.2.3
 django-redis==4.9.0
 flake8==3.5.0
 flake8-commas==2.0.0
@@ -44,6 +44,3 @@ Werkzeug==0.15.3
 
 
 djangorestframework==3.9.1
-
-
-


### PR DESCRIPTION
Fixes error
`dc up`
`backend_1   | ImportError: cannot import name 'gen_filenames`